### PR TITLE
Fix Motion Blur in r174

### DIFF
--- a/motionBlurPass/src/GeometryShader.js
+++ b/motionBlurPass/src/GeometryShader.js
@@ -1,4 +1,4 @@
-import { Matrix4, ShaderChunk } from '//cdn.skypack.dev/three@0.130.1/build/three.module.js';
+import { Matrix4, ShaderChunk } from 'three';
 import { prev_skinning_pars_vertex, velocity_vertex } from './MotionBlurShaderChunks.js';
 
 export const GeometryShader = {

--- a/motionBlurPass/src/MotionBlurPass.js
+++ b/motionBlurPass/src/MotionBlurPass.js
@@ -17,8 +17,8 @@ import {
 	ShaderMaterial,
 	RepeatWrapping,
 	UniformsUtils,
-} from '//cdn.skypack.dev/three@0.130.1/build/three.module.js';
-import { Pass, FullScreenQuad } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/postprocessing/Pass.js';
+} from 'three';
+import { Pass, FullScreenQuad } from 'three/addons/postprocessing/Pass.js';
 import { VelocityShader } from './VelocityShader.js';
 import { GeometryShader } from './GeometryShader.js';
 import { CompositeShader } from './CompositeShader.js';
@@ -164,7 +164,8 @@ export class MotionBlurPass extends Pass {
 
 		// TODO: This is getting called just to set 'currentRenderState' in the renderer
 		// NOTE -- why do we need this?
-		renderer.compile( scene, camera );
+		//console.log( scene, camera );
+		//renderer.compile( scene, camera );
 		this._ensurePrevCameraTransform();
 
 		switch ( debug.display ) {
@@ -391,7 +392,7 @@ export class MotionBlurPass extends Pass {
 			uniforms.prevProjectionMatrix.value.copy( projMat );
 			uniforms.prevModelViewMatrix.value.multiplyMatrices( invMat, data.matrixWorld );
 
-			renderer.renderBufferDirect( camera, null, mesh.geometry, material, mesh, null );
+			renderer.render( this.scene, camera );
 
 			if ( saveState ) {
 

--- a/motionBlurPass/src/MotionBlurPass.js
+++ b/motionBlurPass/src/MotionBlurPass.js
@@ -164,8 +164,7 @@ export class MotionBlurPass extends Pass {
 
 		// TODO: This is getting called just to set 'currentRenderState' in the renderer
 		// NOTE -- why do we need this?
-		//console.log( scene, camera );
-		//renderer.compile( scene, camera );
+		renderer.compile( scene, camera );
 		this._ensurePrevCameraTransform();
 
 		switch ( debug.display ) {
@@ -392,7 +391,7 @@ export class MotionBlurPass extends Pass {
 			uniforms.prevProjectionMatrix.value.copy( projMat );
 			uniforms.prevModelViewMatrix.value.multiplyMatrices( invMat, data.matrixWorld );
 
-			renderer.render( this.scene, camera );
+			renderer.renderBufferDirect( camera, null, mesh.geometry, material, mesh, null );
 
 			if ( saveState ) {
 

--- a/motionBlurPass/src/MotionBlurShaderChunks.js
+++ b/motionBlurPass/src/MotionBlurShaderChunks.js
@@ -1,4 +1,4 @@
-import { ShaderChunk } from '//cdn.skypack.dev/three@0.130.1/build/three.module.js';
+import { ShaderChunk } from 'three';
 
 // Modified ShaderChunk.skinning_pars_vertex to handle
 // a second set of bone information from the previou frame

--- a/motionBlurPass/src/MotionBlurShaderChunks.js
+++ b/motionBlurPass/src/MotionBlurShaderChunks.js
@@ -2,34 +2,28 @@ import { ShaderChunk } from 'three';
 
 // Modified ShaderChunk.skinning_pars_vertex to handle
 // a second set of bone information from the previou frame
-export const prev_skinning_pars_vertex =
-	`
-		#ifdef USE_SKINNING
-		#ifdef BONE_TEXTURE
-			uniform sampler2D prevBoneTexture;
-			mat4 getPrevBoneMatrix( const in float i ) {
-				float j = i * 4.0;
-				float x = mod( j, float( boneTextureSize ) );
-				float y = floor( j / float( boneTextureSize ) );
-				float dx = 1.0 / float( boneTextureSize );
-				float dy = 1.0 / float( boneTextureSize );
-				y = dy * ( y + 0.5 );
-				vec4 v1 = texture2D( prevBoneTexture, vec2( dx * ( x + 0.5 ), y ) );
-				vec4 v2 = texture2D( prevBoneTexture, vec2( dx * ( x + 1.5 ), y ) );
-				vec4 v3 = texture2D( prevBoneTexture, vec2( dx * ( x + 2.5 ), y ) );
-				vec4 v4 = texture2D( prevBoneTexture, vec2( dx * ( x + 3.5 ), y ) );
-				mat4 bone = mat4( v1, v2, v3, v4 );
-				return bone;
-			}
-		#else
-			uniform mat4 prevBoneMatrices[ MAX_BONES ];
-			mat4 getPrevBoneMatrix( const in float i ) {
-				mat4 bone = prevBoneMatrices[ int(i) ];
-				return bone;
-			}
-		#endif
-		#endif
-	`;
+export const prev_skinning_pars_vertex = /* glsl */`
+#ifdef USE_SKINNING
+
+	uniform highp sampler2D prevBoneTexture;
+
+	mat4 getPrevBoneMatrix( const in float i ) {
+
+		int size = textureSize( prevBoneTexture, 0 ).x;
+		int j = int( i ) * 4;
+		int x = j % size;
+		int y = j / size;
+		vec4 v1 = texelFetch( prevBoneTexture, ivec2( x, y ), 0 );
+		vec4 v2 = texelFetch( prevBoneTexture, ivec2( x + 1, y ), 0 );
+		vec4 v3 = texelFetch( prevBoneTexture, ivec2( x + 2, y ), 0 );
+		vec4 v4 = texelFetch( prevBoneTexture, ivec2( x + 3, y ), 0 );
+
+		return mat4( v1, v2, v3, v4 );
+
+	}
+
+#endif
+`;
 
 // Returns the body of the vertex shader for the velocity buffer and
 // outputs the position of the current and last frame positions

--- a/motionBlurPass/src/VelocityShader.js
+++ b/motionBlurPass/src/VelocityShader.js
@@ -1,4 +1,4 @@
-import { Matrix4, ShaderChunk } from '//cdn.skypack.dev/three@0.130.1/build/three.module.js';
+import { Matrix4, ShaderChunk } from 'three';
 import { prev_skinning_pars_vertex, velocity_vertex } from './MotionBlurShaderChunks.js';
 
 export const VelocityShader = {

--- a/motionBlurPass/webgl_postprocessing_perobjectmotionblur.html
+++ b/motionBlurPass/webgl_postprocessing_perobjectmotionblur.html
@@ -40,8 +40,8 @@
 		<script type="importmap">
 			{
   			"imports": {
-    			"three": "https://cdn.jsdelivr.net/npm/three@0.131.2/build/three.module.min.js",
-    			"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.131.2/examples/jsm/"
+    			"three": "https://cdn.jsdelivr.net/npm/three@0.174.0/build/three.module.min.js",
+    			"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.174.0/examples/jsm/"
   			}
 			}
 		</script>
@@ -94,7 +94,7 @@
 				camera.position.set( 0.0, 5, 5 * 3.5 );
 
 				scene = new THREE.Scene();
-				scene.background = new THREE.Color( 0xE91E63 ).convertSRGBToLinear();
+				scene.background = new THREE.Color( 0xE91E63 );
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
@@ -133,7 +133,7 @@
 
 				} ); */
 
-				var geometry = new THREE.TorusKnotBufferGeometry( 2.5, 1, 150, 40 );
+				var geometry = new THREE.TorusKnotGeometry( 2.5, 1, 150, 40 );
 				torusMesh1 = new THREE.Mesh( geometry, standardMaterial );
 				torusMesh1.position.set( -6, 0, 6 );
 				torusMesh1.scale.multiplyScalar( 0.5 );
@@ -189,7 +189,7 @@
 				scene.add( directionalLight );
 
 				// Shadow
-				var plane = new THREE.Mesh( new THREE.PlaneBufferGeometry(), new THREE.ShadowMaterial({ side: THREE.DoubleSide, transparent: true, opacity: 0.5 }));
+				var plane = new THREE.Mesh( new THREE.PlaneGeometry(), new THREE.ShadowMaterial({ side: THREE.DoubleSide, transparent: true, opacity: 0.5 }));
 				plane.receiveShadow = true;
 				plane.rotation.set( -Math.PI / 2, 0, 0 );
 				plane.scale.multiplyScalar( 30 );

--- a/motionBlurPass/webgl_postprocessing_perobjectmotionblur.html
+++ b/motionBlurPass/webgl_postprocessing_perobjectmotionblur.html
@@ -39,10 +39,10 @@
 
 		<script type="importmap">
 			{
-  			"imports": {
-    			"three": "https://cdn.jsdelivr.net/npm/three@0.174.0/build/three.module.min.js",
-    			"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.174.0/examples/jsm/"
-  			}
+				"imports": {
+					"three": "https://cdn.jsdelivr.net/npm/three@0.174.0/build/three.module.min.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.174.0/examples/jsm/"
+				}
 			}
 		</script>
 

--- a/motionBlurPass/webgl_postprocessing_perobjectmotionblur.html
+++ b/motionBlurPass/webgl_postprocessing_perobjectmotionblur.html
@@ -37,19 +37,28 @@
 			A velocity buffer is rendered using the previous and current frame positions for each object </br> which is then used to smear the final frame.
 		</div>
 
+		<script type="importmap">
+			{
+  			"imports": {
+    			"three": "https://cdn.jsdelivr.net/npm/three@0.131.2/build/three.module.min.js",
+    			"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.131.2/examples/jsm/"
+  			}
+			}
+		</script>
+
 		<script type="module">
 
-			import * as THREE from '//cdn.skypack.dev/three@0.130.1/build/three.module.js';
-			import { OrbitControls } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/controls/OrbitControls.js';
-			import { FXAAShader } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/shaders/FXAAShader.js';
-			import { GammaCorrectionShader } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/shaders/GammaCorrectionShader.js';
-			import { EffectComposer } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/postprocessing/EffectComposer.js';
-			import { RenderPass } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/postprocessing/RenderPass.js';
-			import { ShaderPass } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/postprocessing/ShaderPass.js';
-			import { FBXLoader } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/loaders/FBXLoader.js';
+			import * as THREE from 'three';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { FXAAShader } from 'three/addons/shaders/FXAAShader.js';
+			import { GammaCorrectionShader } from 'three/addons/shaders/GammaCorrectionShader.js';
+			import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+			import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
+			import { FBXLoader } from 'three/addons/loaders/FBXLoader.js';
 
-			import Stats from '//cdn.skypack.dev/three@0.130.1/examples/jsm/libs/stats.module.js';
-			import dat from '//cdn.skypack.dev/dat.gui/build/dat.gui.module.js';
+			import Stats from 'three/addons/libs/stats.module.js';
+			import dat from '//cdn.jsdelivr.net/npm/dat.gui/build/dat.gui.module.js';
 
 			import { MotionBlurPass } from './src/MotionBlurPass.js';
 
@@ -85,7 +94,7 @@
 				camera.position.set( 0.0, 5, 5 * 3.5 );
 
 				scene = new THREE.Scene();
-				scene.background = new THREE.Color( 0xE91E63 ).convertGammaToLinear();
+				scene.background = new THREE.Color( 0xE91E63 ).convertSRGBToLinear();
 
 				renderer = new THREE.WebGLRenderer();
 				renderer.setPixelRatio( window.devicePixelRatio );
@@ -100,7 +109,7 @@
 					metalness: 0.5,
 				} );
 
-				var textureLoader = new THREE.TextureLoader();
+				/*var textureLoader = new THREE.TextureLoader();
 				textureLoader.load( 'https://rawgit.com/mrdoob/three.js/r94/examples/textures/floors/FloorsCheckerboard_S_Diffuse.jpg', function ( map ) {
 
 					map.wrapS = THREE.RepeatWrapping;
@@ -122,7 +131,7 @@
 					standardMaterial.normalMap = map;
 					standardMaterial.needsUpdate = true;
 
-				} );
+				} ); */
 
 				var geometry = new THREE.TorusKnotBufferGeometry( 2.5, 1, 150, 40 );
 				torusMesh1 = new THREE.Mesh( geometry, standardMaterial );

--- a/motionBlurPass/webgl_postprocessing_perobjectmotionblur.html
+++ b/motionBlurPass/webgl_postprocessing_perobjectmotionblur.html
@@ -109,7 +109,7 @@
 					metalness: 0.5,
 				} );
 
-				/*var textureLoader = new THREE.TextureLoader();
+				var textureLoader = new THREE.TextureLoader();
 				textureLoader.load( 'https://rawgit.com/mrdoob/three.js/r94/examples/textures/floors/FloorsCheckerboard_S_Diffuse.jpg', function ( map ) {
 
 					map.wrapS = THREE.RepeatWrapping;
@@ -131,7 +131,7 @@
 					standardMaterial.normalMap = map;
 					standardMaterial.needsUpdate = true;
 
-				} ); */
+				} );
 
 				var geometry = new THREE.TorusKnotGeometry( 2.5, 1, 150, 40 );
 				torusMesh1 = new THREE.Mesh( geometry, standardMaterial );


### PR DESCRIPTION
With a reversion in the compile behavior of WebGLRenderer to more closely emulate its behavior pre r132/r131, this can be ported to the latest version of Three.js with minimal effort.