### PR TITLE
Migrate Conditional Lines Sample to r184

### DIFF
--- a/conditional-lines/index.html
+++ b/conditional-lines/index.html
@@ -29,8 +29,8 @@
 	<script type="importmap">
 		{
 			"imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.174.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.174.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
 				"dat.gui": "https://cdn.skypack.dev/dat.gui/build/dat.gui.module.js"
 			}
 		}

--- a/conditional-lines/index.html
+++ b/conditional-lines/index.html
@@ -462,7 +462,6 @@
 				scene.add( camera );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				//renderer.useLegacyLights = true;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.shadowMap.enabled = true;

--- a/conditional-lines/index.html
+++ b/conditional-lines/index.html
@@ -466,7 +466,7 @@
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.shadowMap.enabled = true;
-				renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+				renderer.shadowMap.type = THREE.PCFShadowMap;
 
 				document.body.appendChild( renderer.domElement );
 

--- a/conditional-lines/index.html
+++ b/conditional-lines/index.html
@@ -26,6 +26,15 @@
 				width: 100%;
 			}
 		</style>
+	<script type="importmap">
+		{
+			"imports": {
+				"three": "https://cdn.jsdelivr.net/npm/three@0.174.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.174.0/examples/jsm/",
+				"dat.gui": "https://cdn.skypack.dev/dat.gui/build/dat.gui.module.js"
+			}
+		}
+	</script>
 	</head>
 	<body>
 
@@ -35,15 +44,15 @@
 
 		<script type="module">
 
-			import * as THREE from '//cdn.skypack.dev/three@0.130.1/build/three.module.js';
-			import { GLTFLoader } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/loaders/GLTFLoader.js';
-			import { OrbitControls } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/controls/OrbitControls.js';
-			import { BufferGeometryUtils } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/utils/BufferGeometryUtils.js';
-			import dat from '//cdn.skypack.dev/dat.gui/build/dat.gui.module.js';
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { mergeGeometries, mergeVertices } from 'three/addons/utils/BufferGeometryUtils.js';
+			import dat from 'dat.gui';
 
-			import { LineSegmentsGeometry } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/lines/LineSegmentsGeometry.js';
-			import { LineSegments2 } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/lines/LineSegments2.js';
-			import { LineMaterial } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/lines/LineMaterial.js';
+			import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';
+			import { LineSegments2 } from 'three/addons/lines/LineSegments2.js';
+			import { LineMaterial } from 'three/addons/lines/LineMaterial.js';
 
 			import { OutsideEdgesGeometry } from './src/OutsideEdgesGeometry.js';
 			import { ConditionalEdgesGeometry } from './src/ConditionalEdgesGeometry.js';
@@ -156,8 +165,8 @@
 
 				} );
 
-				const mergedGeometries = BufferGeometryUtils.mergeBufferGeometries( geometry, false );
-				const mergedGeometry = BufferGeometryUtils.mergeVertices( mergedGeometries ).center();
+				const mergedGeometries = mergeGeometries( geometry, false );
+				const mergedGeometry = mergeVertices( mergedGeometries ).center();
 
 				const group = new THREE.Group();
 				const mesh = new THREE.Mesh( mergedGeometry );
@@ -336,7 +345,7 @@
 						const mergeGeom = mesh.geometry.clone();
 						mergeGeom.deleteAttribute( 'uv' );
 						mergeGeom.deleteAttribute( 'uv2' );
-						lineGeom = new OutsideEdgesGeometry( BufferGeometryUtils.mergeVertices( mergeGeom, 1e-3 ) );
+						lineGeom = new OutsideEdgesGeometry( mergeVertices( mergeGeom, 1e-3 ) );
 
 					}
 
@@ -418,7 +427,7 @@
 					}
 
 					// Create the conditional edges geometry and associated material
-					const lineGeom = new ConditionalEdgesGeometry( BufferGeometryUtils.mergeVertices( mergedGeom ) );
+					const lineGeom = new ConditionalEdgesGeometry( mergeVertices( mergedGeom ) );
 					const material = new THREE.ShaderMaterial( ConditionalEdgesShader );
 					material.uniforms.diffuse.value.set( LIGHT_LINES );
 
@@ -453,6 +462,7 @@
 				scene.add( camera );
 
 				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				//renderer.useLegacyLights = true;
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.shadowMap.enabled = true;
@@ -462,7 +472,7 @@
 
 				// Floor
 				floor = new THREE.Mesh(
-					new THREE.PlaneBufferGeometry(),
+					new THREE.PlaneGeometry(),
 					new THREE.ShadowMaterial( { color: LIGHT_LINES, opacity: 0.25, transparent: true } )
 				);
 				floor.rotation.x = - Math.PI / 2;
@@ -487,14 +497,14 @@
 				scene.add( dirLight );
 
 				const cylinder = new THREE.Group();
-				cylinder.add( new THREE.Mesh( new THREE.CylinderBufferGeometry( 0.25, 0.25, 0.5, 100 ) ) );
+				cylinder.add( new THREE.Mesh( new THREE.CylinderGeometry( 0.25, 0.25, 0.5, 100 ) ) );
 				cylinder.children[ 0 ].geometry.computeBoundingBox();
 				cylinder.children[ 0 ].castShadow = true;
 				models.CYLINDER = cylinder;
 
 				models.HELMET = null;
 				new GLTFLoader().load(
-					'https://rawgit.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet.gltf',
+					'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet.gltf',
 					gltf => {
 
 						const model = mergeObject( gltf.scene );

--- a/conditional-lines/src/ColoredShadowMaterial.js
+++ b/conditional-lines/src/ColoredShadowMaterial.js
@@ -1,4 +1,4 @@
-import { ShaderMaterial, UniformsUtils, ShaderLib, Color } from '//cdn.skypack.dev/three@0.130.1/build/three.module.js';
+import { ShaderMaterial, UniformsUtils, ShaderLib, Color } from 'three';
 
 export class ColoredShadowMaterial extends ShaderMaterial {
 
@@ -44,7 +44,6 @@ export class ColoredShadowMaterial extends ShaderMaterial {
 				#endif
 				#include <common>
 				#include <uv_pars_vertex>
-				#include <uv2_pars_vertex>
 				#include <displacementmap_pars_vertex>
 				#include <envmap_pars_vertex>
 				#include <color_pars_vertex>
@@ -56,7 +55,6 @@ export class ColoredShadowMaterial extends ShaderMaterial {
 				#include <clipping_planes_pars_vertex>
 				void main() {
 					#include <uv_vertex>
-					#include <uv2_vertex>
 					#include <color_vertex>
 					#include <beginnormal_vertex>
 					#include <morphnormal_vertex>
@@ -93,7 +91,6 @@ export class ColoredShadowMaterial extends ShaderMaterial {
 				#include <dithering_pars_fragment>
 				#include <color_pars_fragment>
 				#include <uv_pars_fragment>
-				#include <uv2_pars_fragment>
 				#include <map_pars_fragment>
 				#include <alphamap_pars_fragment>
 				#include <aomap_pars_fragment>
@@ -136,7 +133,7 @@ export class ColoredShadowMaterial extends ShaderMaterial {
 
 					gl_FragColor = vec4( outgoingLight, diffuseColor.a );
 					#include <tonemapping_fragment>
-					#include <encodings_fragment>
+					#include <colorspace_fragment>
 					#include <fog_fragment>
 					#include <premultiplied_alpha_fragment>
 					#include <dithering_fragment>

--- a/conditional-lines/src/ColoredShadowMaterial.js
+++ b/conditional-lines/src/ColoredShadowMaterial.js
@@ -1,175 +1,29 @@
-import { ShaderMaterial, UniformsUtils, ShaderLib, Color } from 'three';
+import { MeshPhongMaterial, Color } from 'three';
 
-export class ColoredShadowMaterial extends ShaderMaterial {
+export class ColoredShadowMaterial extends MeshPhongMaterial {
 
-	get color() {
+	constructor( parameters = {} ) {
 
-		return this.uniforms.diffuse.value;
-
-	}
-
-	get shadowColor() {
-
-		return this.uniforms.shadowColor.value;
+		super( parameters );
+		this.shadowColor = new Color( parameters.shadowColor ?? 0xff0000 );
 
 	}
 
-	set shininess( v ) {
+	onBeforeCompile( shader ) {
 
-		this.uniforms.shininess.value = v;
+		shader.uniforms.shadowColor = { value: this.shadowColor };
+		shader.fragmentShader = 'uniform vec3 shadowColor;\n' + shader.fragmentShader;
+		shader.fragmentShader = shader.fragmentShader.replace(
+			'#include <dithering_fragment>',
+			`#include <dithering_fragment>
+			gl_FragColor.rgb = mix( shadowColor.rgb, diffuse, min( gl_FragColor.r, 1.0 ) );`
+		);
 
 	}
-	get shininess() {
 
-		return this.uniforms.shininess.value;
+	customProgramCacheKey() {
 
-	}
-
-	constructor( options ) {
-
-		super( {
-			uniforms: UniformsUtils.merge( [
-				ShaderLib.phong.uniforms,
-				{
-					shadowColor: {
-						value: new Color( 0xff0000 ),
-					},
-				},
-			] ),
-			vertexShader: `
-				#define PHONG
-				varying vec3 vViewPosition;
-				#ifndef FLAT_SHADED
-					varying vec3 vNormal;
-				#endif
-				#include <common>
-				#include <uv_pars_vertex>
-				#include <displacementmap_pars_vertex>
-				#include <envmap_pars_vertex>
-				#include <color_pars_vertex>
-				#include <fog_pars_vertex>
-				#include <morphtarget_pars_vertex>
-				#include <skinning_pars_vertex>
-				#include <shadowmap_pars_vertex>
-				#include <logdepthbuf_pars_vertex>
-				#include <clipping_planes_pars_vertex>
-				void main() {
-					#include <uv_vertex>
-					#include <color_vertex>
-					#include <beginnormal_vertex>
-					#include <morphnormal_vertex>
-					#include <skinbase_vertex>
-					#include <skinnormal_vertex>
-					#include <defaultnormal_vertex>
-				#ifndef FLAT_SHADED
-					vNormal = normalize( transformedNormal );
-				#endif
-					#include <begin_vertex>
-					#include <morphtarget_vertex>
-					#include <skinning_vertex>
-					#include <displacementmap_vertex>
-					#include <project_vertex>
-					#include <logdepthbuf_vertex>
-					#include <clipping_planes_vertex>
-					vViewPosition = - mvPosition.xyz;
-					#include <worldpos_vertex>
-					#include <envmap_vertex>
-					#include <shadowmap_vertex>
-					#include <fog_vertex>
-				}
-			`,
-			fragmentShader: `
-				#define PHONG
-				uniform vec3 diffuse;
-				uniform vec3 emissive;
-				uniform vec3 specular;
-				uniform float shininess;
-				uniform float opacity;
-				uniform vec3 shadowColor;
-				#include <common>
-				#include <packing>
-				#include <dithering_pars_fragment>
-				#include <color_pars_fragment>
-				#include <uv_pars_fragment>
-				#include <map_pars_fragment>
-				#include <alphamap_pars_fragment>
-				#include <aomap_pars_fragment>
-				#include <lightmap_pars_fragment>
-				#include <emissivemap_pars_fragment>
-				#include <envmap_common_pars_fragment>
-				#include <envmap_pars_fragment>
-				#include <cube_uv_reflection_fragment>
-				#include <fog_pars_fragment>
-				#include <bsdfs>
-				#include <lights_pars_begin>
-				#include <lights_phong_pars_fragment>
-				#include <shadowmap_pars_fragment>
-				#include <bumpmap_pars_fragment>
-				#include <normalmap_pars_fragment>
-				#include <specularmap_pars_fragment>
-				#include <logdepthbuf_pars_fragment>
-				#include <clipping_planes_pars_fragment>
-				void main() {
-					#include <clipping_planes_fragment>
-					vec4 diffuseColor = vec4( 1.0, 1.0, 1.0, opacity );
-					ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
-					vec3 totalEmissiveRadiance = emissive;
-					#include <logdepthbuf_fragment>
-					#include <map_fragment>
-					#include <color_fragment>
-					#include <alphamap_fragment>
-					#include <alphatest_fragment>
-					#include <specularmap_fragment>
-					#include <normal_fragment_begin>
-					#include <normal_fragment_maps>
-					#include <emissivemap_fragment>
-					#include <lights_phong_fragment>
-					#include <lights_fragment_begin>
-					#include <lights_fragment_maps>
-					#include <lights_fragment_end>
-					#include <aomap_fragment>
-					vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;
-					#include <envmap_fragment>
-
-					gl_FragColor = vec4( outgoingLight, diffuseColor.a );
-					#include <tonemapping_fragment>
-					#include <colorspace_fragment>
-					#include <fog_fragment>
-					#include <premultiplied_alpha_fragment>
-					#include <dithering_fragment>
-
-					gl_FragColor.rgb = mix(
-						shadowColor.rgb,
-						diffuse.rgb,
-						min( gl_FragColor.r, 1.0 )
-					);
-
-				}
-
-			`,
-
-		} );
-
-		Object.defineProperties( this, {
-			opacity: {
-
-				set( v ) {
-
-					this.uniforms.opacity.value = v;
-
-				},
-
-				get() {
-
-					return this.uniforms.opacity.value;
-
-				}
-
-			}
-		} );
-
-		this.setValues( options );
-		this.lights = true;
+		return 'ColoredShadowMaterial';
 
 	}
 

--- a/conditional-lines/src/ConditionalEdgesGeometry.js
+++ b/conditional-lines/src/ConditionalEdgesGeometry.js
@@ -1,4 +1,4 @@
-import { BufferGeometry, Vector3, BufferAttribute, Triangle } from '//cdn.skypack.dev/three@0.130.1/build/three.module.js';
+import { BufferGeometry, Vector3, BufferAttribute, Triangle } from 'three';
 
 const vec0 = new Vector3();
 const vec1 = new Vector3();

--- a/conditional-lines/src/ConditionalEdgesShader.js
+++ b/conditional-lines/src/ConditionalEdgesShader.js
@@ -1,4 +1,4 @@
-import { Color } from '//cdn.skypack.dev/three@0.130.1/build/three.module.js';
+import { Color } from 'three';
 
 export const ConditionalEdgesShader = {
 
@@ -87,7 +87,7 @@ export const ConditionalEdgesShader = {
 			gl_FragColor = vec4( outgoingLight, diffuseColor.a );
 
 			#include <tonemapping_fragment>
-			#include <encodings_fragment>
+			#include <colorspace_fragment>
 			#include <fog_fragment>
 			#include <premultiplied_alpha_fragment>
 

--- a/conditional-lines/src/Lines2/ConditionalLineMaterial.js
+++ b/conditional-lines/src/Lines2/ConditionalLineMaterial.js
@@ -3,7 +3,7 @@ import {
 	UniformsLib,
 	UniformsUtils,
 	Vector2
-} from '//cdn.skypack.dev/three@0.130.1/build/three.module.js';
+} from 'three';
 /**
  * parameters = {
  *  color: <hex>,
@@ -266,7 +266,7 @@ const shader = {
 			gl_FragColor = vec4( diffuseColor.rgb, diffuseColor.a );
 
 			#include <tonemapping_fragment>
-			#include <encodings_fragment>
+			#include <colorspace_fragment>
 			#include <fog_fragment>
 			#include <premultiplied_alpha_fragment>
 

--- a/conditional-lines/src/Lines2/ConditionalLineSegmentsGeometry.js
+++ b/conditional-lines/src/Lines2/ConditionalLineSegmentsGeometry.js
@@ -1,5 +1,5 @@
-import * as THREE from '//cdn.skypack.dev/three@0.130.1/build/three.module.js';
-import { LineSegmentsGeometry } from '//cdn.skypack.dev/three@0.130.1/examples/jsm/lines/LineSegmentsGeometry.js';
+import * as THREE from 'three';
+import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';
 
 export class ConditionalLineSegmentsGeometry extends LineSegmentsGeometry {
 

--- a/conditional-lines/src/OutsideEdgesGeometry.js
+++ b/conditional-lines/src/OutsideEdgesGeometry.js
@@ -1,4 +1,4 @@
-import { BufferGeometry, Vector3, BufferAttribute } from '//cdn.skypack.dev/three@0.130.1/build/three.module.js';
+import { BufferGeometry, Vector3, BufferAttribute } from 'three';
 
 const vec = new Vector3();
 export class OutsideEdgesGeometry extends BufferGeometry {


### PR DESCRIPTION
Migrates conditional lines sample to r184.

Changes:

Get rid of uv2_* shader chunks
Change CylinderBufferGeometry to CylinderGeometry
Set new link for GLTF Helmet
Have ColoredShadowMaterial extend MeshPhongMaterial through onBeforeCompile
PCFSoftShadowMap to PCFShadowMap (may want to keep if behavior is significantly different)