### PR TITLE
Node Material Conditional Lines Sample

### DIFF
--- a/conditional-lines/webgpu/index.html
+++ b/conditional-lines/webgpu/index.html
@@ -51,20 +51,21 @@
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { mergeGeometries, mergeVertices } from 'three/addons/utils/BufferGeometryUtils.js';
-			import { WebGLNodesHandler } from 'three/addons/tsl/WebGLNodesHandler.js';
 			import dat from 'dat.gui';
 
-			// Existing WebGL materials
-			import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';
+			// WebGPU compliant geometry (replacement for WebGL LineSegments2)
 			import { LineSegments2 } from 'three/addons/lines/webgpu/LineSegments2.js';
+
+			// Existing custom geometry classes
+			import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';
 			import { OutsideEdgesGeometry } from '../src/OutsideEdgesGeometry.js';
 			import { ConditionalEdgesGeometry } from '../src/ConditionalEdgesGeometry.js';
 			import { ConditionalLineSegmentsGeometry } from '../src/Lines2/ConditionalLineSegmentsGeometry.js';
 
-			// Node materials
-			import { ColoredShadowNodeMaterial } from './nodeMaterials/ColoredShadowNodeMaterial.js';
-			import { ConditionalEdgesNodeMaterial } from './nodeMaterials/ConditionalEdgesNodeMaterial.js';
-			import { ConditionalLineNodeMaterial } from './nodeMaterials/ConditionalLineNodeMaterial.js';
+			// Custom Node materials
+			import { ColoredShadowNodeMaterial } from './nodeMaterials/ColoredShadowNodeMaterial.js'; // port of ColoredShadowMaterial.js
+			import { ConditionalEdgesNodeMaterial } from './nodeMaterials/ConditionalEdgesNodeMaterial.js'; // port of ConditionalEdgesShader.js
+			import { ConditionalLineNodeMaterial } from './nodeMaterials/ConditionalLineNodeMaterial.js'; // port of Lines2/ConditionalLineMaterial.js
 
 			// globals
 			const params = {

--- a/conditional-lines/webgpu/index.html
+++ b/conditional-lines/webgpu/index.html
@@ -47,6 +47,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
+			import { WebGPURenderer } from 'three/webgpu';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { mergeGeometries, mergeVertices } from 'three/addons/utils/BufferGeometryUtils.js';
@@ -66,10 +67,8 @@
 			import { ConditionalEdgesNodeMaterial } from './nodeMaterials/ConditionalEdgesNodeMaterial.js';
 			import { ConditionalLineNodeMaterial } from './nodeMaterials/ConditionalLineNodeMaterial.js';
 
-
 			// globals
-			var params = {
-				currentRenderer: 'WebGL',
+			const params = {
 				colors: 'LIGHT',
 				backgroundColor: '#0d2a28',
 				modelColor: '#0d2a28',
@@ -82,13 +81,23 @@
 				display: 'THRESHOLD_EDGES',
 				displayConditionalEdges: true,
 				thickness: 1,
-				useThickLines: false,
 				model: 'HELMET',
 
 				randomize: () => randomizeColors(),
 			};
-			let renderer, webgpuRenderer;
-			let camera, scene, controls, edgesModel, originalModel, backgroundModel, conditionalModel, shadowModel, floor, depthModel, gui;
+			let renderer;
+			let camera, scene, controls;
+			// Default Edges
+			let edgesModel;
+			// Initial group created from model
+			let originalModel
+			// Unlit model underneath colored edges
+			let backgroundModel;
+			// Model that modifies the conditional lines
+			let conditionalModel;
+			// Lit model underneath colored edges
+			let shadowModel;
+			let floor, depthModel, gui;
 
 			const models = {};
 			const color = new THREE.Color();
@@ -104,7 +113,7 @@
 			const DARK_LINES = 0xb0bec5;
 			const DARK_SHADOW = 0x2c2e2f;
 
-			init();
+			await init();
 			animate();
 
 			function randomizeColors() {
@@ -361,15 +370,8 @@
 					line.scale.copy( mesh.scale );
 					line.rotation.copy( mesh.rotation );
 
-					const thickLineGeom = new LineSegmentsGeometry().fromEdgesGeometry( lineGeom );
-					const thickLines = new LineSegments2( thickLineGeom, new LineMaterial( { color: LIGHT_LINES, linewidth: 3 } ) );
-					thickLines.position.copy( mesh.position );
-					thickLines.scale.copy( mesh.scale );
-					thickLines.rotation.copy( mesh.rotation );
-
 					parent.remove( mesh );
 					parent.add( line );
-					parent.add( thickLines );
 
 				}
 
@@ -445,7 +447,11 @@
 					line.rotation.copy( mesh.rotation );
 
 					const thickLineGeom = new ConditionalLineSegmentsGeometry().fromConditionalEdgesGeometry( lineGeom );
-					const thickLines = new LineSegments2( thickLineGeom, new ConditionalLineNodeMaterial( { color: LIGHT_LINES, linewidth: 2 } ) );
+					const thickLines = new LineSegments2( thickLineGeom, new ConditionalLineNodeMaterial( {
+						color: LIGHT_LINES,
+						linewidth: 10,
+						worldUnits: true
+					} ) );
 					thickLines.position.copy( mesh.position );
 					thickLines.scale.copy( mesh.scale );
 					thickLines.rotation.copy( mesh.rotation );
@@ -458,7 +464,7 @@
 
 			}
 
-			function init() {
+			async function init() {
 
 				// initialize renderer, scene, camera
 				scene = new THREE.Scene();
@@ -468,8 +474,9 @@
 				camera.position.set( -1, 0.5, 2 ).multiplyScalar( 0.75 );
 				scene.add( camera );
 
-				renderer = new THREE.WebGLRenderer( { antialias: true } );
-				renderer.setNodesHandler( new WebGLNodesHandler() );
+				// WebGPURenderer
+				renderer = new WebGPURenderer({antialias: true});
+				await renderer.init();
 				renderer.setPixelRatio( window.devicePixelRatio );
 				renderer.setSize( window.innerWidth, window.innerHeight );
 				renderer.shadowMap.enabled = true;
@@ -577,8 +584,6 @@
 
 				linesFolder.add( params, 'displayConditionalEdges' );
 
-				linesFolder.add( params, 'useThickLines' );
-
 				linesFolder.add( params, 'thickness', 0, 5 );
 
 				linesFolder.open();
@@ -597,6 +602,9 @@
 
 				renderer.setSize( width, height );
 				renderer.setPixelRatio( window.devicePixelRatio );
+
+				webgpuRenderer.setSize(width, height)
+				webgpuRenderer.setPixelRatio(window.devicePixelRatio)
 
 			}
 
@@ -630,17 +638,24 @@
 					conditionalModel.visible = params.displayConditionalEdges;
 					conditionalModel.traverse( c => {
 
-						if ( c.material && c.material.resolution ) {
-
-							renderer.getSize( c.material.resolution );
-							c.material.resolution.multiplyScalar( window.devicePixelRatio );
-							c.material.linewidth = params.thickness;
-
-						}
-
 						if ( c.material ) {
 
-							c.visible = c instanceof LineSegments2 ? params.useThickLines : ! params.useThickLines;
+							// Legacy ShaderMaterial: needs manual resolution update
+							if ( c.material.resolution ) {
+
+								renderer.getSize( c.material.resolution );
+								c.material.resolution.multiplyScalar( window.devicePixelRatio );
+
+							}
+
+							// All line materials (ShaderMaterial or Line2NodeMaterial subclass)
+							if ( c.material.linewidth !== undefined ) {
+
+								c.material.linewidth = params.thickness;
+
+							}
+
+							c.visible = c instanceof LineSegments2 ? false : true;
 							c.material.color = linesColor;
 
 						}
@@ -654,17 +669,22 @@
 
 					edgesModel.traverse( c => {
 
-						if ( c.material && c.material.resolution ) {
-
-							renderer.getSize( c.material.resolution );
-							c.material.resolution.multiplyScalar( window.devicePixelRatio );
-							c.material.linewidth = params.thickness;
-
-						}
-
 						if ( c.material ) {
 
-							c.visible = c instanceof LineSegments2 ? params.useThickLines : ! params.useThickLines;
+							if ( c.material.resolution ) {
+
+								renderer.getSize( c.material.resolution );
+								c.material.resolution.multiplyScalar( window.devicePixelRatio );
+
+							}
+
+							if ( c.material.linewidth !== undefined ) {
+
+								c.material.linewidth = params.thickness;
+
+							}
+
+							c.visible = c instanceof LineSegments2 ? false : true;
 							c.material.color.set( linesColor );
 
 						}
@@ -725,7 +745,7 @@
 
 			function render() {
 
-				params.currentRenderer = 'WebGL' ? renderer.render( scene, camera ) : webgpuRenderer.render(scene, camera);
+				renderer.render(scene, camera);
 
 			}
 

--- a/conditional-lines/webgpu/index.html
+++ b/conditional-lines/webgpu/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>threejs webgl - general conditional edges</title>
+		<title>threejs webgpu - general conditional edges</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 		<style>
@@ -47,7 +47,7 @@
 		<script type="module">
 
 			import * as THREE from 'three';
-			import { WebGPURenderer } from 'three/webgpu';
+			import { WebGPURenderer, Line2NodeMaterial } from 'three/webgpu';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 			import { mergeGeometries, mergeVertices } from 'three/addons/utils/BufferGeometryUtils.js';
@@ -56,8 +56,7 @@
 
 			// Existing WebGL materials
 			import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';
-			import { LineSegments2 } from 'three/addons/lines/LineSegments2.js';
-			import { LineMaterial } from 'three/addons/lines/LineMaterial.js';
+			import { LineSegments2 } from 'three/addons/lines/webgpu/LineSegments2.js';
 			import { OutsideEdgesGeometry } from '../src/OutsideEdgesGeometry.js';
 			import { ConditionalEdgesGeometry } from '../src/ConditionalEdgesGeometry.js';
 			import { ConditionalLineSegmentsGeometry } from '../src/Lines2/ConditionalLineSegmentsGeometry.js';
@@ -81,6 +80,7 @@
 				display: 'THRESHOLD_EDGES',
 				displayConditionalEdges: true,
 				thickness: 1,
+				useThickLines: false,
 				model: 'HELMET',
 
 				randomize: () => randomizeColors(),
@@ -370,8 +370,15 @@
 					line.scale.copy( mesh.scale );
 					line.rotation.copy( mesh.rotation );
 
+					const thickLineGeom = new LineSegmentsGeometry().fromEdgesGeometry( lineGeom );
+					const thickLines = new LineSegments2( thickLineGeom, new Line2NodeMaterial( { color: LIGHT_LINES, linewidth: 3 } ) );
+					thickLines.position.copy( mesh.position );
+					thickLines.scale.copy( mesh.scale );
+					thickLines.rotation.copy( mesh.rotation );
+
 					parent.remove( mesh );
 					parent.add( line );
+					parent.add( thickLines );
 
 				}
 
@@ -449,8 +456,7 @@
 					const thickLineGeom = new ConditionalLineSegmentsGeometry().fromConditionalEdgesGeometry( lineGeom );
 					const thickLines = new LineSegments2( thickLineGeom, new ConditionalLineNodeMaterial( {
 						color: LIGHT_LINES,
-						linewidth: 10,
-						worldUnits: true
+						linewidth: 2
 					} ) );
 					thickLines.position.copy( mesh.position );
 					thickLines.scale.copy( mesh.scale );
@@ -584,6 +590,8 @@
 
 				linesFolder.add( params, 'displayConditionalEdges' );
 
+				linesFolder.add( params, 'useThickLines' );
+
 				linesFolder.add( params, 'thickness', 0, 5 );
 
 				linesFolder.open();
@@ -602,9 +610,6 @@
 
 				renderer.setSize( width, height );
 				renderer.setPixelRatio( window.devicePixelRatio );
-
-				webgpuRenderer.setSize(width, height)
-				webgpuRenderer.setPixelRatio(window.devicePixelRatio)
 
 			}
 
@@ -640,23 +645,15 @@
 
 						if ( c.material ) {
 
-							// Legacy ShaderMaterial: needs manual resolution update
-							if ( c.material.resolution ) {
-
-								renderer.getSize( c.material.resolution );
-								c.material.resolution.multiplyScalar( window.devicePixelRatio );
-
-							}
-
-							// All line materials (ShaderMaterial or Line2NodeMaterial subclass)
+							// All line materials (LineBasicMaterial or Line2NodeMaterial subclass)
 							if ( c.material.linewidth !== undefined ) {
 
 								c.material.linewidth = params.thickness;
 
 							}
 
-							c.visible = c instanceof LineSegments2 ? false : true;
-							c.material.color = linesColor;
+							c.visible = c instanceof LineSegments2 ? params.useThickLines : ! params.useThickLines;
+							c.material.color.set( linesColor );
 
 						}
 
@@ -671,20 +668,13 @@
 
 						if ( c.material ) {
 
-							if ( c.material.resolution ) {
-
-								renderer.getSize( c.material.resolution );
-								c.material.resolution.multiplyScalar( window.devicePixelRatio );
-
-							}
-
 							if ( c.material.linewidth !== undefined ) {
 
 								c.material.linewidth = params.thickness;
 
 							}
 
-							c.visible = c instanceof LineSegments2 ? false : true;
+							c.visible = c instanceof LineSegments2 ? params.useThickLines : ! params.useThickLines;
 							c.material.color.set( linesColor );
 
 						}

--- a/conditional-lines/webgpu/index.html
+++ b/conditional-lines/webgpu/index.html
@@ -1,0 +1,736 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>threejs webgl - general conditional edges</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				background-color: #000000;
+				margin: 0px;
+				padding: 0;
+				overflow: hidden;
+				font-family: Monospace;
+				font-size: 13px;
+				text-align: center;
+				color: #666;
+			}
+
+			a {
+				color:#5d928d;
+			}
+
+			#info {
+				position: absolute;
+				padding-top: 10px;
+				width: 100%;
+			}
+		</style>
+	<script type="importmap">
+		{
+			"imports": {
+				"three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.module.js",
+				"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.tsl.js",
+				"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.webgpu.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/",
+				"dat.gui": "https://cdn.skypack.dev/dat.gui/build/dat.gui.module.js"
+			}
+     	}
+	</script>
+	</head>
+	<body>
+
+		<div id="info">
+			<a href="http://threejs.org" target="_blank" rel="noopener">three.js</a> - General Conditional Edges by <a href="http://gkjohnson.github.io" target="_blank" rel="noopener">Garrett Johnson</a>
+		</div>
+
+		<script type="module">
+
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { mergeGeometries, mergeVertices } from 'three/addons/utils/BufferGeometryUtils.js';
+			import { WebGLNodesHandler } from 'three/addons/tsl/WebGLNodesHandler.js';
+			import dat from 'dat.gui';
+
+			// Existing WebGL materials
+			import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';
+			import { LineSegments2 } from 'three/addons/lines/LineSegments2.js';
+			import { LineMaterial } from 'three/addons/lines/LineMaterial.js';
+			import { OutsideEdgesGeometry } from '../src/OutsideEdgesGeometry.js';
+			import { ConditionalEdgesGeometry } from '../src/ConditionalEdgesGeometry.js';
+			import { ConditionalLineSegmentsGeometry } from '../src/Lines2/ConditionalLineSegmentsGeometry.js';
+
+			// Node materials
+			import { ColoredShadowNodeMaterial } from './nodeMaterials/ColoredShadowNodeMaterial.js';
+			import { ConditionalEdgesNodeMaterial } from './nodeMaterials/ConditionalEdgesNodeMaterial.js';
+			import { ConditionalLineNodeMaterial } from './nodeMaterials/ConditionalLineNodeMaterial.js';
+
+
+			// globals
+			var params = {
+				currentRenderer: 'WebGL',
+				colors: 'LIGHT',
+				backgroundColor: '#0d2a28',
+				modelColor: '#0d2a28',
+				lineColor: '#ffb400',
+				shadowColor: '#44491f',
+
+				lit: false,
+				opacity: 0.85,
+				threshold: 40,
+				display: 'THRESHOLD_EDGES',
+				displayConditionalEdges: true,
+				thickness: 1,
+				useThickLines: false,
+				model: 'HELMET',
+
+				randomize: () => randomizeColors(),
+			};
+			let renderer, webgpuRenderer;
+			let camera, scene, controls, edgesModel, originalModel, backgroundModel, conditionalModel, shadowModel, floor, depthModel, gui;
+
+			const models = {};
+			const color = new THREE.Color();
+			const color2 = new THREE.Color();
+
+			const LIGHT_BACKGROUND = 0xeeeeee;
+			const LIGHT_MODEL = 0xffffff;
+			const LIGHT_LINES = 0x455A64;
+			const LIGHT_SHADOW = 0xc4c9cb;
+
+			const DARK_BACKGROUND = 0x111111;
+			const DARK_MODEL = 0x111111;
+			const DARK_LINES = 0xb0bec5;
+			const DARK_SHADOW = 0x2c2e2f;
+
+			init();
+			animate();
+
+			function randomizeColors() {
+
+				const lineH = Math.random();
+				const lineS = Math.random() * 0.2 + 0.8;
+				const lineL = Math.random() * 0.2 + 0.4;
+
+				const lineColor = '#' + color.setHSL( lineH, lineS, lineL ).getHexString();
+				const backgroundColor = '#' + color.setHSL(
+					( lineH + 0.35 + 0.3 * Math.random() ) % 1.0,
+					lineS * ( 0.25 + Math.random() * 0.75 ),
+					1.0 - lineL,
+				).getHexString();
+
+				color.set( lineColor );
+				color2.set( backgroundColor );
+				const shadowColor = '#' + color.lerp( color2, 0.7 ).getHexString();
+
+				params.shadowColor = shadowColor;
+				params.lineColor = lineColor;
+				params.backgroundColor = backgroundColor;
+				params.modelColor = backgroundColor;
+				params.colors = 'CUSTOM';
+
+				initGui();
+
+			};
+
+			function updateModel() {
+
+				originalModel = models[ params.model ];
+
+				initEdgesModel();
+
+				initBackgroundModel();
+
+				initConditionalModel();
+
+			}
+
+			function mergeObject( object ) {
+
+				object.updateMatrixWorld( true );
+
+				const geometry = [];
+				object.traverse( c => {
+
+					if ( c.isMesh ) {
+
+						const g = c.geometry;
+						g.applyMatrix4( c.matrixWorld );
+						for ( const key in g.attributes ) {
+
+							if ( key !== 'position' && key !== 'normal' ) {
+
+								g.deleteAttribute( key );
+
+							}
+
+						}
+						geometry.push( g.toNonIndexed() );
+
+					}
+
+				} );
+
+				const mergedGeometries = mergeGeometries( geometry, false );
+				const mergedGeometry = mergeVertices( mergedGeometries ).center();
+
+				const group = new THREE.Group();
+				const mesh = new THREE.Mesh( mergedGeometry );
+				group.add( mesh );
+				return group;
+
+			}
+
+			function initBackgroundModel() {
+
+				if ( backgroundModel ) {
+
+					backgroundModel.parent.remove( backgroundModel );
+					shadowModel.parent.remove( shadowModel );
+					depthModel.parent.remove( depthModel );
+
+					backgroundModel.traverse( c => {
+
+						if ( c.isMesh ) {
+
+							c.material.dispose();
+
+						}
+
+					} );
+
+					shadowModel.traverse( c => {
+
+						if ( c.isMesh ) {
+
+							c.material.dispose();
+
+						}
+
+					} );
+
+					depthModel.traverse( c => {
+
+						if ( c.isMesh ) {
+
+							c.material.dispose();
+
+						}
+
+					} );
+
+				}
+
+				if ( ! originalModel ) {
+
+					return;
+
+				}
+
+				backgroundModel = originalModel.clone();
+				backgroundModel.traverse( c => {
+
+					if ( c.isMesh ) {
+
+						c.material = new THREE.MeshBasicMaterial( { color: LIGHT_MODEL } );
+						c.material.polygonOffset = true;
+						c.material.polygonOffsetFactor = 1;
+						c.material.polygonOffsetUnits = 1;
+						c.renderOrder = 2;
+
+					}
+
+				} );
+				scene.add( backgroundModel );
+
+				shadowModel = originalModel.clone();
+				shadowModel.traverse( c => {
+
+					if ( c.isMesh ) {
+
+						c.material = new ColoredShadowNodeMaterial( { color: LIGHT_MODEL, shininess: 1.0 } );
+						c.material.polygonOffset = true;
+						c.material.polygonOffsetFactor = 1;
+						c.material.polygonOffsetUnits = 1;
+						c.receiveShadow = true;
+						c.renderOrder = 2;
+
+					}
+
+				} );
+				scene.add( shadowModel );
+
+				depthModel = originalModel.clone();
+				depthModel.traverse( c => {
+
+					if ( c.isMesh ) {
+
+						c.material = new THREE.MeshBasicMaterial( { color: LIGHT_MODEL } );
+						c.material.polygonOffset = true;
+						c.material.polygonOffsetFactor = 1;
+						c.material.polygonOffsetUnits = 1;
+						c.material.colorWrite = false;
+						c.renderOrder = 1;
+
+					}
+
+				} );
+				scene.add( depthModel );
+
+			}
+
+			function initEdgesModel() {
+
+				// remove any previous model
+				if ( edgesModel ) {
+
+					edgesModel.parent.remove( edgesModel );
+					edgesModel.traverse( c => {
+
+						if ( c.isMesh ) {
+
+							if ( Array.isArray( c.material ) ) {
+
+								c.material.forEach( m => m.dispose() );
+
+							} else {
+
+								c.material.dispose();
+
+							}
+
+						}
+
+					} );
+
+				}
+
+				// early out if there's no model loaded
+				if ( ! originalModel ) {
+
+					return;
+
+				}
+
+				// store the model and add it to the scene to display
+				// behind the lines
+				edgesModel = originalModel.clone();
+				scene.add( edgesModel );
+
+				// early out if we're not displaying any type of edge
+				if ( params.display === 'NONE' ) {
+
+					edgesModel.visible = false;
+					return;
+
+				}
+
+				const meshes = [];
+				edgesModel.traverse( c => {
+
+					if ( c.isMesh ) {
+
+						meshes.push( c );
+
+					}
+
+				} );
+
+				for ( const key in meshes ) {
+
+					const mesh = meshes[ key ];
+					const parent = mesh.parent;
+
+					let lineGeom;
+					if ( params.display === 'THRESHOLD_EDGES' ) {
+
+						lineGeom = new THREE.EdgesGeometry( mesh.geometry, params.threshold );
+
+					} else {
+
+						const mergeGeom = mesh.geometry.clone();
+						mergeGeom.deleteAttribute( 'uv' );
+						mergeGeom.deleteAttribute( 'uv2' );
+						lineGeom = new OutsideEdgesGeometry( mergeVertices( mergeGeom, 1e-3 ) );
+
+					}
+
+					const line = new THREE.LineSegments( lineGeom, new THREE.LineBasicMaterial( { color: LIGHT_LINES } ) );
+					line.position.copy( mesh.position );
+					line.scale.copy( mesh.scale );
+					line.rotation.copy( mesh.rotation );
+
+					const thickLineGeom = new LineSegmentsGeometry().fromEdgesGeometry( lineGeom );
+					const thickLines = new LineSegments2( thickLineGeom, new LineMaterial( { color: LIGHT_LINES, linewidth: 3 } ) );
+					thickLines.position.copy( mesh.position );
+					thickLines.scale.copy( mesh.scale );
+					thickLines.rotation.copy( mesh.rotation );
+
+					parent.remove( mesh );
+					parent.add( line );
+					parent.add( thickLines );
+
+				}
+
+			}
+
+			function initConditionalModel() {
+
+				// remove the original model
+				if ( conditionalModel ) {
+
+					conditionalModel.parent.remove( conditionalModel );
+					conditionalModel.traverse( c => {
+
+						if ( c.isMesh ) {
+
+							c.material.dispose();
+
+						}
+
+					} );
+
+				}
+
+				// if we have no loaded model then exit
+				if ( ! originalModel ) {
+
+					return;
+
+				}
+
+				conditionalModel = originalModel.clone();
+				scene.add( conditionalModel );
+				conditionalModel.visible = false;
+
+				// get all meshes
+				const meshes = [];
+				conditionalModel.traverse( c => {
+
+					if ( c.isMesh ) {
+
+						meshes.push( c );
+
+					}
+
+				} );
+
+				for ( const key in meshes ) {
+
+					const mesh = meshes[ key ];
+					const parent = mesh.parent;
+
+					// Remove everything but the position attribute
+					const mergedGeom = mesh.geometry.clone();
+					for ( const key in mergedGeom.attributes ) {
+
+						if ( key !== 'position' ) {
+
+							mergedGeom.deleteAttribute( key );
+
+						}
+
+					}
+
+					// Create the conditional edges geometry and associated material
+					const lineGeom = new ConditionalEdgesGeometry( mergeVertices( mergedGeom ) );
+					const material = new ConditionalEdgesNodeMaterial();
+					material.color = LIGHT_LINES;
+
+					// Create the line segments objects and replace the mesh
+					const line = new THREE.LineSegments( lineGeom, material );
+					line.position.copy( mesh.position );
+					line.scale.copy( mesh.scale );
+					line.rotation.copy( mesh.rotation );
+
+					const thickLineGeom = new ConditionalLineSegmentsGeometry().fromConditionalEdgesGeometry( lineGeom );
+					const thickLines = new LineSegments2( thickLineGeom, new ConditionalLineNodeMaterial( { color: LIGHT_LINES, linewidth: 2 } ) );
+					thickLines.position.copy( mesh.position );
+					thickLines.scale.copy( mesh.scale );
+					thickLines.rotation.copy( mesh.rotation );
+
+					parent.remove( mesh );
+					parent.add( line );
+					parent.add( thickLines );
+
+				}
+
+			}
+
+			function init() {
+
+				// initialize renderer, scene, camera
+				scene = new THREE.Scene();
+				scene.background = new THREE.Color( LIGHT_BACKGROUND );
+
+				camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 0.1, 2000 );
+				camera.position.set( -1, 0.5, 2 ).multiplyScalar( 0.75 );
+				scene.add( camera );
+
+				renderer = new THREE.WebGLRenderer( { antialias: true } );
+				renderer.setNodesHandler( new WebGLNodesHandler() );
+				renderer.setPixelRatio( window.devicePixelRatio );
+				renderer.setSize( window.innerWidth, window.innerHeight );
+				renderer.shadowMap.enabled = true;
+				renderer.shadowMap.type = THREE.PCFShadowMap;
+
+				document.body.appendChild( renderer.domElement );
+
+				// Floor
+				floor = new THREE.Mesh(
+					new THREE.PlaneGeometry(),
+					new THREE.ShadowMaterial( { color: LIGHT_LINES, opacity: 0.25, transparent: true } )
+				);
+				floor.rotation.x = - Math.PI / 2;
+				floor.scale.setScalar( 20 );
+				floor.receiveShadow = true;
+				scene.add( floor );
+
+				// Lights
+				const dirLight = new THREE.DirectionalLight( 0xffffff, 1.0 );
+				dirLight.position.set( 5, 10, 5 );
+				dirLight.castShadow = true;
+				dirLight.shadow.bias = -1e-10;
+				dirLight.shadow.mapSize.width = 2048;
+				dirLight.shadow.mapSize.height = 2048;
+
+				window.dirLight = dirLight;
+
+				const shadowCam = dirLight.shadow.camera;
+				shadowCam.left = shadowCam.bottom = -1;
+				shadowCam.right = shadowCam.top = 1;
+
+				scene.add( dirLight );
+
+				const cylinder = new THREE.Group();
+				cylinder.add( new THREE.Mesh( new THREE.CylinderGeometry( 0.25, 0.25, 0.5, 100 ) ) );
+				cylinder.children[ 0 ].geometry.computeBoundingBox();
+				cylinder.children[ 0 ].castShadow = true;
+				models.CYLINDER = cylinder;
+
+				models.HELMET = null;
+				new GLTFLoader().load(
+					'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/FlightHelmet/glTF/FlightHelmet.gltf',
+					gltf => {
+
+						const model = mergeObject( gltf.scene );
+						model.children[ 0 ].geometry.computeBoundingBox();
+						model.children[ 0 ].castShadow = true;
+
+						models.HELMET = model;
+						updateModel();
+
+					}
+				);
+
+				// camera controls
+				controls = new OrbitControls( camera, renderer.domElement );
+				controls.maxDistance = 200;
+
+				window.addEventListener( 'resize', onWindowResize, false );
+
+				initGui();
+
+			}
+
+			function initGui() {
+
+				if ( gui ) {
+
+					gui.destroy();
+
+				}
+
+				// dat gui
+				gui = new dat.GUI();
+				gui.width = 300;
+				gui.add( params, 'colors', [ 'LIGHT', 'DARK', 'CUSTOM' ] );
+				gui.addColor( params, 'backgroundColor' );
+				gui.addColor( params, 'modelColor' );
+				gui.addColor( params, 'lineColor' );
+				gui.addColor( params, 'shadowColor' );
+				gui.add( params, 'randomize' );
+
+				const modelFolder = gui.addFolder( 'model' );
+
+				modelFolder.add( params, 'model', Object.keys( models ) ).onChange( updateModel );
+
+				modelFolder.add( params, 'opacity' ).min( 0 ).max( 1.0 ).step( 0.01 );
+
+				modelFolder.add( params, 'lit' );
+
+				modelFolder.open();
+
+				const linesFolder = gui.addFolder( 'conditional lines' );
+
+				linesFolder.add( params, 'threshold' )
+					.min( 0 )
+					.max( 120 )
+					.onChange( initEdgesModel );
+
+				linesFolder.add( params, 'display', [
+					'THRESHOLD_EDGES',
+					'NORMAL_EDGES',
+					'NONE',
+				] ).onChange( initEdgesModel );
+
+				linesFolder.add( params, 'displayConditionalEdges' );
+
+				linesFolder.add( params, 'useThickLines' );
+
+				linesFolder.add( params, 'thickness', 0, 5 );
+
+				linesFolder.open();
+
+				gui.open();
+
+			}
+
+			function onWindowResize() {
+
+				var width = window.innerWidth;
+				var height = window.innerHeight;
+
+				camera.aspect = width / height;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( width, height );
+				renderer.setPixelRatio( window.devicePixelRatio );
+
+			}
+
+			function animate() {
+
+				requestAnimationFrame( animate );
+
+				let linesColor = LIGHT_LINES;
+				let modelColor = LIGHT_MODEL;
+				let backgroundColor = LIGHT_BACKGROUND;
+				let shadowColor = LIGHT_SHADOW;
+
+				if ( params.colors === 'DARK' ) {
+
+					linesColor = DARK_LINES;
+					modelColor = DARK_MODEL;
+					backgroundColor = DARK_BACKGROUND;
+					shadowColor = DARK_SHADOW;
+
+				} else if ( params.colors === 'CUSTOM' ) {
+
+					linesColor = params.lineColor;
+					modelColor = params.modelColor;
+					backgroundColor = params.backgroundColor;
+					shadowColor = params.shadowColor;
+
+				}
+
+				if ( conditionalModel ) {
+
+					conditionalModel.visible = params.displayConditionalEdges;
+					conditionalModel.traverse( c => {
+
+						if ( c.material && c.material.resolution ) {
+
+							renderer.getSize( c.material.resolution );
+							c.material.resolution.multiplyScalar( window.devicePixelRatio );
+							c.material.linewidth = params.thickness;
+
+						}
+
+						if ( c.material ) {
+
+							c.visible = c instanceof LineSegments2 ? params.useThickLines : ! params.useThickLines;
+							c.material.color = linesColor;
+
+						}
+
+					} );
+
+				}
+
+
+				if ( edgesModel ) {
+
+					edgesModel.traverse( c => {
+
+						if ( c.material && c.material.resolution ) {
+
+							renderer.getSize( c.material.resolution );
+							c.material.resolution.multiplyScalar( window.devicePixelRatio );
+							c.material.linewidth = params.thickness;
+
+						}
+
+						if ( c.material ) {
+
+							c.visible = c instanceof LineSegments2 ? params.useThickLines : ! params.useThickLines;
+							c.material.color.set( linesColor );
+
+						}
+
+					} );
+
+				}
+
+				if ( backgroundModel ) {
+
+					backgroundModel.visible = ! params.lit;
+					backgroundModel.traverse( c => {
+
+						if ( c.isMesh ) {
+
+							c.material.transparent = params.opacity !== 1.0;
+							c.material.opacity = params.opacity;
+							c.material.color.set( modelColor );
+
+						}
+
+					} );
+
+				}
+
+				if ( shadowModel ) {
+
+					shadowModel.visible = params.lit;
+					shadowModel.traverse( c => {
+
+						if ( c.isMesh ) {
+
+							c.material.transparent = params.opacity !== 1.0;
+							c.material.opacity = params.opacity;
+							c.material.color.set( modelColor );
+							c.material.shadowColor.set( shadowColor );
+
+						}
+
+					} );
+
+				}
+
+				if ( originalModel ) {
+
+					floor.position.y = originalModel.children[ 0 ].geometry.boundingBox.min.y;
+
+				}
+
+				scene.background.set( backgroundColor );
+				floor.material.color.set( shadowColor );
+				floor.material.opacity = params.opacity;
+				floor.visible = params.lit;
+
+				render();
+
+			}
+
+			function render() {
+
+				params.currentRenderer = 'WebGL' ? renderer.render( scene, camera ) : webgpuRenderer.render(scene, camera);
+
+			}
+
+		</script>
+
+	</body>
+
+</html>

--- a/conditional-lines/webgpu/nodeMaterials/ColoredShadowNodeMaterial.js
+++ b/conditional-lines/webgpu/nodeMaterials/ColoredShadowNodeMaterial.js
@@ -1,0 +1,37 @@
+import { Color } from 'three';
+import { MeshPhongNodeMaterial } from 'three/webgpu';
+import { vec4, diffuseColor, min, uniform, mix } from 'three/tsl';
+
+export class ColoredShadowNodeMaterial extends MeshPhongNodeMaterial {
+
+	static get type() {
+
+		return 'ColoredShadowNodeMaterial';
+
+	}
+	constructor( parameters = {} ) {
+
+		super( parameters );
+		this._shadowColor = uniform( new Color( parameters.shadowColor ?? 0xff0000 ) );
+
+	}
+	get shadowColor() {
+
+		return this._shadowColor.value;
+
+	}
+	set shadowColor( val ) {
+
+		this._shadowColor.value.set( val );
+
+	}
+
+	setupOutput( builder, outputNode ) {
+
+		const brightness = min( outputNode.r, 1.0 );
+		const mixedColor = mix( this._shadowColor, diffuseColor.rgb, brightness );
+		return super.setupOutput( builder, vec4( mixedColor, outputNode.a ) );
+
+	}
+
+}

--- a/conditional-lines/webgpu/nodeMaterials/ConditionalEdgesNodeMaterial.js
+++ b/conditional-lines/webgpu/nodeMaterials/ConditionalEdgesNodeMaterial.js
@@ -29,7 +29,11 @@ export class ConditionalEdgesNodeMaterial extends NodeMaterial {
 
 	setup( builder ) {
 
-		this.colorNode = vec4( this._diffuse, this._opacity );
+		this.colorNode = Fn( () => {
+
+			return this._diffuse;
+
+		} )();
 
 		this.vertexNode = Fn( () => {
 
@@ -49,15 +53,12 @@ export class ConditionalEdgesNodeMaterial extends NodeMaterial {
 			p0.divAssign( p0.w );
 			p1.divAssign( p1.w );
 
-			// Direction of the segment and its screen-space orthogonal (normal)
 			const dir = p1.xy.sub( p0.xy );
 			const norm = vec2( negate( dir.y ), dir.x );
 
 			const c0dir = c0.xy.sub( p1.xy );
 			const c1dir = c1.xy.sub( p1.xy );
 
-			// Control points on opposite sides of the edge normal → silhouette → draw
-			// Control points on the same side → interior edge → collapse vertex to discard
 			const d0 = dot( normalize( norm ), normalize( c0dir ) );
 			const d1 = dot( normalize( norm ), normalize( c1dir ) );
 			const discardFlag = float( sign( d0 ).notEqual( sign( d1 ) ) );

--- a/conditional-lines/webgpu/nodeMaterials/ConditionalEdgesNodeMaterial.js
+++ b/conditional-lines/webgpu/nodeMaterials/ConditionalEdgesNodeMaterial.js
@@ -1,0 +1,73 @@
+import { Color } from 'three';
+import { NodeMaterial } from 'three/webgpu';
+import {
+	uniform, float, Fn, attribute, dot, normalize, sign,
+	cameraProjectionMatrix, modelViewMatrix, vec4, vec2,
+	negate, positionLocal, select
+} from 'three/tsl';
+
+export class ConditionalEdgesNodeMaterial extends NodeMaterial {
+
+	constructor() {
+
+		super();
+		this._diffuse = uniform( new Color() );
+
+	}
+
+	get color() {
+
+		return this._diffuse.value;
+
+	}
+
+	set color( val ) {
+
+		this._diffuse.value.set( val );
+
+	}
+
+	setup( builder ) {
+
+		this.colorNode = vec4( this._diffuse, this._opacity );
+
+		this.vertexNode = Fn( () => {
+
+			const control0 = attribute( 'control0' );
+			const control1 = attribute( 'control1' );
+			const direction = attribute( 'direction' );
+
+			const mvp = cameraProjectionMatrix.mul( modelViewMatrix );
+			const clipPos = mvp.mul( vec4( positionLocal, 1.0 ) ).toVar( 'clipPos' );
+			const c0 = mvp.mul( vec4( control0, 1.0 ) ).toVar( 'c0' );
+			const c1 = mvp.mul( vec4( control1, 1.0 ) ).toVar( 'c1' );
+			const p0 = mvp.mul( vec4( positionLocal, 1.0 ) ).toVar( 'p0' );
+			const p1 = mvp.mul( vec4( positionLocal.add( direction ), 1.0 ) ).toVar( 'p1' );
+
+			c0.divAssign( c0.w );
+			c1.divAssign( c1.w );
+			p0.divAssign( p0.w );
+			p1.divAssign( p1.w );
+
+			// Direction of the segment and its screen-space orthogonal (normal)
+			const dir = p1.xy.sub( p0.xy );
+			const norm = vec2( negate( dir.y ), dir.x );
+
+			const c0dir = c0.xy.sub( p1.xy );
+			const c1dir = c1.xy.sub( p1.xy );
+
+			// Control points on opposite sides of the edge normal → silhouette → draw
+			// Control points on the same side → interior edge → collapse vertex to discard
+			const d0 = dot( normalize( norm ), normalize( c0dir ) );
+			const d1 = dot( normalize( norm ), normalize( c1dir ) );
+			const discardFlag = float( sign( d0 ).notEqual( sign( d1 ) ) );
+
+			return select( discardFlag.greaterThan( 0.5 ), c0, clipPos );
+
+		} )();
+
+		super.setup( builder );
+
+	}
+
+}

--- a/conditional-lines/webgpu/nodeMaterials/ConditionalLineNodeMaterial.js
+++ b/conditional-lines/webgpu/nodeMaterials/ConditionalLineNodeMaterial.js
@@ -1,0 +1,80 @@
+
+import {
+	float,
+	vec2,
+	vec4,
+	attribute,
+	cameraProjectionMatrix,
+	modelViewMatrix,
+	dot,
+	normalize,
+	sign,
+	negate,
+	select
+} from 'three/tsl';
+import { Line2NodeMaterial } from 'three/webgpu';
+
+class ConditionalLineNodeMaterial extends Line2NodeMaterial {
+
+	static get type() {
+
+		return 'ConditionalLineNodeMaterial';
+
+	}
+
+	constructor( parameters = {} ) {
+
+		super( parameters );
+		this.isConditionalLineNodeMaterial = true;
+
+	}
+
+	setupVertex( builder ) {
+
+		// Fat-line clip-space position computed by Line2NodeMaterial.
+		const mvp = super.setupVertex( builder );
+
+		const control0 = attribute( 'control0' );
+		const control1 = attribute( 'control1' );
+		const direction = attribute( 'direction' );
+		const instanceStart = attribute( 'instanceStart' );
+
+		// Project edge endpoints and control points into clip space then NDC.
+		// Using .div(clip.w) instead of toVar/divAssign keeps this as a pure
+		// node expression consistent with the PointsNodeMaterial pattern.
+		const proj = cameraProjectionMatrix.mul( modelViewMatrix );
+
+		const c0Clip = proj.mul( vec4( control0, 1.0 ) );
+		const c1Clip = proj.mul( vec4( control1, 1.0 ) );
+		const p0Clip = proj.mul( vec4( instanceStart, 1.0 ) );
+		const p1Clip = proj.mul( vec4( instanceStart.add( direction ), 1.0 ) );
+
+		const c0 = c0Clip.div( c0Clip.w );
+		const c1 = c1Clip.div( c1Clip.w );
+		const p0 = p0Clip.div( p0Clip.w );
+		const p1 = p1Clip.div( p1Clip.w );
+
+		// Screen-space edge direction and its orthogonal (normal).
+		const segDir = p1.xy.sub( p0.xy );
+		const segNorm = vec2( negate( segDir.y ), segDir.x );
+
+		// Vectors from the reference point (p1) to each control point.
+		const c0dir = c0.xy.sub( p1.xy );
+		const c1dir = c1.xy.sub( p1.xy );
+
+		// Project each control-point direction onto the edge normal.
+		// Same sign  → both on the same side → interior crease → discard.
+		// Diff signs → opposite sides → silhouette edge → keep.
+		const d0 = dot( normalize( segNorm ), normalize( c0dir ) );
+		const d1 = dot( normalize( segNorm ), normalize( c1dir ) );
+		const discardFlag = float( sign( d0 ).notEqual( sign( d1 ) ) );
+
+		// Interior edge: collapse all vertices to c0 (degenerate zero-area
+		// triangle, effectively invisible).  Silhouette: pass through mvp.
+		return select( discardFlag.greaterThan( 0.5 ), c0, mvp );
+
+	}
+
+}
+
+export { ConditionalLineNodeMaterial };

--- a/conditional-lines/webgpu/nodeMaterials/ConditionalLineNodeMaterial.js
+++ b/conditional-lines/webgpu/nodeMaterials/ConditionalLineNodeMaterial.js
@@ -36,8 +36,8 @@ class ConditionalLineNodeMaterial extends Line2NodeMaterial {
 
 	setupVertex( builder ) {
 
-		// clip-space position computed by Line2NodeMaterial.
 		const mvp = super.setupVertex( builder );
+		const lineClip = this.vertexNode || mvp;
 
 		const control0 = attribute( 'control0' );
 		const control1 = attribute( 'control1' );
@@ -66,7 +66,11 @@ class ConditionalLineNodeMaterial extends Line2NodeMaterial {
 		const d1 = dot( normalize( segNorm ), normalize( c1dir ) );
 		const discardFlag = float( sign( d0 ).notEqual( sign( d1 ) ) );
 
-		return select( discardFlag.greaterThan( 0.5 ), c0, mvp );
+		// Collapse all vertices of a discarded segment onto a single point so the
+		// instanced quad degenerates and rasterizes nothing.
+		this.vertexNode = select( discardFlag.greaterThan( 0.5 ), c0, lineClip );
+
+		return this.vertexNode;
 
 	}
 

--- a/conditional-lines/webgpu/nodeMaterials/ConditionalLineNodeMaterial.js
+++ b/conditional-lines/webgpu/nodeMaterials/ConditionalLineNodeMaterial.js
@@ -13,7 +13,6 @@ import {
 	select
 } from 'three/tsl';
 import { Line2NodeMaterial } from 'three/webgpu';
-
 class ConditionalLineNodeMaterial extends Line2NodeMaterial {
 
 	static get type() {
@@ -29,9 +28,15 @@ class ConditionalLineNodeMaterial extends Line2NodeMaterial {
 
 	}
 
+	set lineColor( val ) {
+
+		this.lineColorNode = val;
+
+	}
+
 	setupVertex( builder ) {
 
-		// Fat-line clip-space position computed by Line2NodeMaterial.
+		// clip-space position computed by Line2NodeMaterial.
 		const mvp = super.setupVertex( builder );
 
 		const control0 = attribute( 'control0' );
@@ -39,9 +44,6 @@ class ConditionalLineNodeMaterial extends Line2NodeMaterial {
 		const direction = attribute( 'direction' );
 		const instanceStart = attribute( 'instanceStart' );
 
-		// Project edge endpoints and control points into clip space then NDC.
-		// Using .div(clip.w) instead of toVar/divAssign keeps this as a pure
-		// node expression consistent with the PointsNodeMaterial pattern.
 		const proj = cameraProjectionMatrix.mul( modelViewMatrix );
 
 		const c0Clip = proj.mul( vec4( control0, 1.0 ) );
@@ -54,23 +56,16 @@ class ConditionalLineNodeMaterial extends Line2NodeMaterial {
 		const p0 = p0Clip.div( p0Clip.w );
 		const p1 = p1Clip.div( p1Clip.w );
 
-		// Screen-space edge direction and its orthogonal (normal).
 		const segDir = p1.xy.sub( p0.xy );
 		const segNorm = vec2( negate( segDir.y ), segDir.x );
 
-		// Vectors from the reference point (p1) to each control point.
 		const c0dir = c0.xy.sub( p1.xy );
 		const c1dir = c1.xy.sub( p1.xy );
 
-		// Project each control-point direction onto the edge normal.
-		// Same sign  → both on the same side → interior crease → discard.
-		// Diff signs → opposite sides → silhouette edge → keep.
 		const d0 = dot( normalize( segNorm ), normalize( c0dir ) );
 		const d1 = dot( normalize( segNorm ), normalize( c1dir ) );
 		const discardFlag = float( sign( d0 ).notEqual( sign( d1 ) ) );
 
-		// Interior edge: collapse all vertices to c0 (degenerate zero-area
-		// triangle, effectively invisible).  Silhouette: pass through mvp.
 		return select( discardFlag.greaterThan( 0.5 ), c0, mvp );
 
 	}


### PR DESCRIPTION
Port of the Conditional Lines Sample to WebGPU Node Materials.

I'm using this file structure convention for ports of existing samples to WebGPU

```txt
sample-name/
     index.html
     src/
     webgpu/
          index.html
          src/
```

The existing WebGL sample would exist at https://gkjohnson.github.io/threejs-sandbox/conditional-lines/index.html

The new WebGPU sample would exist at https://gkjohnson.github.io/threejs-sandbox/conditional-lines/webgpu/index.html

The PR is still in draft for now because there is an issue with adjusting line width's that seems contrary to the expected result as compared to the existing Three.js Line2NodeMaterial samples.